### PR TITLE
Update MAP with DICOM standard-compliant ContourData element (decimal places)

### DIFF
--- a/app/operators/dcm2nii_operator.py
+++ b/app/operators/dcm2nii_operator.py
@@ -51,7 +51,7 @@ class Dcm2NiiOperator(Operator):
         # Set output path for next operator
         op_output.set(DataPath(input_path))
 
-        logging.info(f"Performed dcm2niix conversion")
+        logging.info("Performed dcm2niix conversion")
 
         logging.info(f"End {self.compute.__name__}")
 

--- a/app/operators/rtstructwriter_operator.py
+++ b/app/operators/rtstructwriter_operator.py
@@ -33,7 +33,7 @@ class RTStructWriterOperator(Operator):
 
         nii_seg_files = list_nii_files(nii_seg_output_path)
 
-        logging.info(f"Creating RT Struct ...")
+        logging.info("Creating RT Struct ...")
 
         # create new RT Struct - requires original DICOM
         rtstruct = RTStructBuilder.create_new(dicom_series_path=dcm_input_path)
@@ -44,7 +44,7 @@ class RTStructWriterOperator(Operator):
 
         # round RT Struct ContourData to 10 d.p.
         # TODO remove once new PyPI release of rt-utils
-        logging.info(f"Rounding ContourData values to 10 d.p. ...")
+        logging.info("Rounding ContourData values to 10 d.p. ...")
 
         # loop over ROIs in rtstruct (1 per TotalSegmentator region)
         for roi_idx in range(0, len(rtstruct.ds.ROIContourSequence)):
@@ -58,14 +58,14 @@ class RTStructWriterOperator(Operator):
                         # contour_data_list.append(decimal_check(c, 10))
                         if decimal_check(c, 10) is True:
                             rtstruct.ds.ROIContourSequence[roi_idx].ContourSequence[cs_idx].ContourData[idx] = round(c, 10)
-        logging.info(f"Rounding ContourData values complete ...")
+        logging.info("Rounding ContourData values complete ...")
 
         # save RT Struct
         rtstruct.save(os.path.join(dcm_output_path, rt_struct_output_filename))
 
         logging.info(f"RT Struct written to {os.path.join(dcm_output_path, rt_struct_output_filename)}")
 
-        logging.info(f"RT Struct creation complete ...")
+        logging.info("RT Struct creation complete ...")
 
         logging.info(f"End {self.compute.__name__}")
 

--- a/app/operators/rtstructwriter_operator.py
+++ b/app/operators/rtstructwriter_operator.py
@@ -42,6 +42,24 @@ class RTStructWriterOperator(Operator):
         for idx, filename in enumerate(nii_seg_files):
             add_nii_roi_to_rtstruct(nii_seg_output_path, filename, rtstruct)
 
+        # round RT Struct ContourData to 10 d.p.
+        # TODO remove once new PyPI release of rt-utils
+        logging.info(f"Rounding ContourData values to 10 d.p. ...")
+
+        # loop over ROIs in rtstruct (1 per TotalSegmentator region)
+        for roi_idx in range(0, len(rtstruct.ds.ROIContourSequence)):
+            # if ROI has contours
+            if len(rtstruct.ds.ROIContourSequence[roi_idx].ContourSequence) > 0:
+                # loop over the contours within the ROI
+                for cs_idx in range(0, len(rtstruct.ds.ROIContourSequence[roi_idx].ContourSequence)):
+                    # contour_data_list = []  # for debugging
+                    # loop over the ContourData list
+                    for idx, c in enumerate(rtstruct.ds.ROIContourSequence[roi_idx].ContourSequence[cs_idx].ContourData):
+                        # contour_data_list.append(decimal_check(c, 10))
+                        if decimal_check(c, 10) is True:
+                            rtstruct.ds.ROIContourSequence[roi_idx].ContourSequence[cs_idx].ContourData[idx] = round(c, 10)
+        logging.info(f"Rounding ContourData values complete ...")
+
         # save RT Struct
         rtstruct.save(os.path.join(dcm_output_path, rt_struct_output_filename))
 
@@ -86,6 +104,22 @@ def add_nii_roi_to_rtstruct(nii_seg_path, nii_filename, rtstruct):
         mask=nii_img,
         name=seg_name
     )
+
+
+def decimal_check(num, dec_places):
+    """
+    Check if number has more than N decimal places
+    :param num: Input number to check
+    :param dec_places: Number of decimal places to check
+    :return: True/False
+
+    # TODO remove once new PyPI release of rt-utils
+    """
+    dec_len = len(str(num).split(".")[1])
+    if dec_len > dec_places:
+        return True
+    elif dec_len <= dec_places:
+        return False
 
 
 def list_nii_files(nii_seg_output_path):

--- a/app/operators/rtstructwriter_operator.py
+++ b/app/operators/rtstructwriter_operator.py
@@ -55,7 +55,7 @@ class RTStructWriterOperator(Operator):
                     # contour_data_list = []  # for debugging
                     # loop over the ContourData list
                     for idx, c in enumerate(rtstruct.ds.ROIContourSequence[roi_idx].ContourSequence[cs_idx].ContourData):
-                        # contour_data_list.append(decimal_check(c, 10))
+                        # contour_data_list.append(decimal_check(c, 10))  # for debugging
                         if decimal_check(c, 10) is True:
                             rtstruct.ds.ROIContourSequence[roi_idx].ContourSequence[cs_idx].ContourData[idx] = round(c, 10)
         logging.info("Rounding ContourData values complete ...")

--- a/app/operators/totalsegmentator_operator.py
+++ b/app/operators/totalsegmentator_operator.py
@@ -36,7 +36,7 @@ class TotalSegmentatorOperator(Operator):
         # Run TotalSegmentator
         subprocess.run(["TotalSegmentator", "-i", nii_input_file, "-o", nii_seg_output_path])
 
-        logging.info(f"Performed TotalSegmentator processing")
+        logging.info("Performed TotalSegmentator processing")
 
         # Set output path for next operator
         op_output.set(DataPath(input_path))  # cludge to avoid op_output not exist error

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ python-gdcm==3.0.20
 pytz==2022.7
 PyWavelets==1.4.1
 requests==2.28.1
-rt-utils==1.2.7
+-e git+https://github.com/qurit/rt-utils@769acd6#egg=rt-utils
 scikit-image==0.19.3
 scikit-learn==1.2.0
 scipy==1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ multidict==6.0.4
 multiprocess==0.70.14
 networkx==2.8.8
 nibabel==4.0.2
-nnunet-customized==1.1
+nnunet-customized==1.2
 numpy==1.24.1
 opencv-python==4.7.0.68
 p-tqdm==1.4.0
@@ -55,7 +55,7 @@ six==1.16.0
 threadpoolctl==3.1.0
 tifffile==2022.10.10
 torch==1.13.1
-TotalSegmentator==1.1
+TotalSegmentator==1.5.5
 tqdm==4.64.1
 traceback2==1.4.0
 typeguard==2.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,6 @@ scikit-learn==1.2.0
 scipy==1.9.3
 SimpleITK==2.2.1
 six==1.16.0
-sklearn==0.0.post1
 threadpoolctl==3.1.0
 tifffile==2022.10.10
 torch==1.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ python-gdcm==3.0.20
 pytz==2022.7
 PyWavelets==1.4.1
 requests==2.28.1
--e git+https://github.com/qurit/rt-utils@769acd6#egg=rt-utils
+rt-utils==1.2.7
 scikit-image==0.19.3
 scikit-learn==1.2.0
 scipy==1.9.3


### PR DESCRIPTION
This PR updates the `rtstructwriter_operator` so that ContourData tag decimal places conform with DICOM standard.

This is implemented in the MAP code, which is required until rt-utils issues new PyPI release, at which point this code can be removed.