### PR TITLE
WIP: automated package and publish of MAP

### DIFF
--- a/.github/workflows/publish_map.yml
+++ b/.github/workflows/publish_map.yml
@@ -1,43 +1,53 @@
 # Workflow to publish TotalSegmentator-AIDE MAP on GHCR
 
-name: Create and publish MAP
+name: Build and package MAP
 
 on:
   push:
     branches: ['24_publish_map']
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ '3.10' ]
+
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+    - name: Install Python packages
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest pytest-cov
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    - name: Display installed pip packages
+      run: |
+        pip list
+
+    - name: Initial packaging of MAP-init
+      run: |
+        monai-deploy package app --tag map-init -l DEBUG
+
+    - name: Package 3rd-party software into MAP
+      run: |
+        docker build -t map app/
+
+#    # TODO: add step to run the MAP using test data
+#    - name: Test MAP end-to-end
+#      run: |
+#        monai-deploy run map input-test-data-in-repo/ output/

--- a/.github/workflows/publish_map.yml
+++ b/.github/workflows/publish_map.yml
@@ -1,0 +1,43 @@
+# Workflow to publish TotalSegmentator-AIDE MAP on GHCR
+
+name: Create and publish MAP
+
+on:
+  push:
+    branches: ['24_publish_map']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
WIP: GitHub Action to automatically build and publish the MAP on release.

Currently, build is almost working.

TODO:
- figure out why map-init build failed (https://github.com/GSTT-CSC/TotalSegmentator-AIDE/actions/runs/4949810507)
   - nb: this says succeeded, but map-init stage failed because failed to get one of the layers. Action continued because currently the 3rd-party software step is independent of the previous step.
 - add in check after MAP build complete
 - add in check to verify that built MAP is sufficient for release