### PR TITLE
Unit tests for dcm2niix_operator

### DIFF
--- a/app/operators/dcm2nii_operator.py
+++ b/app/operators/dcm2nii_operator.py
@@ -53,8 +53,7 @@ class Dcm2NiiOperator(Operator):
             os.mkdir(dirname)
 
     @staticmethod
-    def load_selected_series(op_input):
-        study_selected_series = op_input.get("study_selected_series_list")[0]  # nb: load single DICOM series
+    def load_selected_series(study_selected_series):
         selected_series = study_selected_series.selected_series
         num_instances_in_series = len(selected_series[0].series.get_sop_instances())
         return selected_series, num_instances_in_series
@@ -97,7 +96,8 @@ class Dcm2NiiOperator(Operator):
 
         # load series, copy across .dcm files
         # assumption: single DICOM series
-        selected_series, num_instances_in_series = self.load_selected_series(op_input)
+        study_selected_series = op_input.get("study_selected_series_list")[0]  # nb: load single DICOM series from Study
+        selected_series, num_instances_in_series = self.load_selected_series(study_selected_series)
         self.copy_dcm_to_workdir(selected_series, num_instances_in_series)
 
         # run dcm2niix

--- a/app/operators/dcm2nii_operator.py
+++ b/app/operators/dcm2nii_operator.py
@@ -58,12 +58,13 @@ class Dcm2NiiOperator(Operator):
         num_instances_in_series = len(selected_series[0].series.get_sop_instances())
         return selected_series, num_instances_in_series
 
-    def copy_dcm_to_workdir(self, selected_series, num_instances_in_series):
+    @staticmethod
+    def copy_dcm_to_workdir(selected_series, num_instances_in_series, workdir, dcm_input_dir):
         for idx, f in enumerate(selected_series[0].series.get_sop_instances()):
             dcm_filepath = f._sop.filename
             if str(dcm_filepath).lower().endswith('.dcm'):
                 logging.info(f"Copying DICOM Instance: {idx + 1}/{num_instances_in_series} ...")
-                destination_path = shutil.copy2(dcm_filepath, os.path.join(self.workdir, self.dcm_input_dir))
+                destination_path = shutil.copy2(dcm_filepath, os.path.join(workdir, dcm_input_dir))
                 logging.info(f"Copied {dcm_filepath} to {destination_path}")
 
     @staticmethod
@@ -98,7 +99,7 @@ class Dcm2NiiOperator(Operator):
         # assumption: single DICOM series
         study_selected_series = op_input.get("study_selected_series_list")[0]  # nb: load single DICOM series from Study
         selected_series, num_instances_in_series = self.load_selected_series(study_selected_series)
-        self.copy_dcm_to_workdir(selected_series, num_instances_in_series)
+        self.copy_dcm_to_workdir(selected_series, num_instances_in_series, self.workdir, self.dcm_input_dir)
 
         # run dcm2niix
         # TODO: check Eq_ files output by dcm2niix

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import unittest
 import subprocess
 import nibabel as nib
 import numpy as np
@@ -8,15 +7,15 @@ import numpy as np
 from pathlib import Path
 
 
-class TestDcm2NiiConversion(unittest.TestCase):
+class TestDcm2NiiConversion:
+    def setup_method(self):
+        self.dcm_ref_path = Path('data/dcm2nii/dcm/')
+        self.nii_ref_file = Path('data/dcm2nii/nii/ct-test-data.nii.gz')
+        self.nii_gen_path = Path('data/dcm2nii/nii_generated/')
 
-    def setUp(self):
-        self.dcm_ref_path = Path('tests/data/dcm2nii/dcm/')
-        self.nii_ref_file = Path('tests/data/dcm2nii/nii/ct-test-data.nii.gz')
-        self.nii_gen_path = Path('tests/data/dcm2nii/nii_generated/')
-
-    def tearDown(self):
-        shutil.rmtree(self.nii_gen_path)
+    def test_load_nifti(self):
+        nii_obj = nib.load(self.nii_ref_file)
+        assert issubclass(type(nii_obj), nib.nifti1.Nifti1Image)
 
     def test_dcm2niix(self):
         os.makedirs(self.nii_gen_path, exist_ok=True)
@@ -25,8 +24,7 @@ class TestDcm2NiiConversion(unittest.TestCase):
         img_ref = nib.load(self.nii_ref_file).get_fdata()
         img_gen = nib.load(self.nii_gen_path / 'generated-ct-test-data.nii.gz').get_fdata()
         images_equal = np.array_equal(img_ref, img_gen)
-        self.assertTrue(images_equal, "dcm2niix conversion issue – reference and generated nii files not equal")
+        assert images_equal, f"Generated image array not equal to reference image array"
 
-
-if __name__ == '__main__':
-    unittest.main()
+        # remove test generated images
+        shutil.rmtree(self.nii_gen_path)

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -1,15 +1,11 @@
 import os
 import shutil
-import subprocess
 import nibabel as nib
 import numpy as np
-from monai.deploy.core import DataPath, ExecutionContext, InputContext, IOType, Operator, OutputContext, Application
-from monai.deploy.core.domain.dicom_series_selection import StudySelectedSeries
-from monai.deploy.operators import DICOMDataLoaderOperator
-from monai.deploy.operators import DICOMSeriesSelectorOperator
-
 from pathlib import Path
 
+from monai.deploy.operators import DICOMDataLoaderOperator
+from monai.deploy.operators import DICOMSeriesSelectorOperator
 from app.operators.dcm2nii_operator import Dcm2NiiOperator
 
 

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -20,36 +20,44 @@ class TestDcm2NiiConversion:
         self.nii_gen_path = Path('tests/data/dcm2nii/nii_generated/')
         self.nii_gen_filename = "generated-ct-test-data"
 
+        # create monai_workdir as already exists within a MAP
         self.monai_workdir = Path('tests/data/dcm2nii/monai_workdir')
         os.makedirs(self.monai_workdir, exist_ok=True)
 
         # setup MONAI Deploy loader and selector operators for DICOM testing
         current_file_dir = Path(__file__).parent.resolve()
-        data_path = current_file_dir.joinpath("../").joinpath(self.dcm_ref_path)  # absolute path
+        self.dcm_ref_path_abs = current_file_dir.joinpath("../").joinpath(self.dcm_ref_path).absolute()  # absolute path
         loader = DICOMDataLoaderOperator()
         selector = DICOMSeriesSelectorOperator(all_matched=True)
-        study_list = loader.load_data_to_studies(data_path.absolute())
+        study_list = loader.load_data_to_studies(self.dcm_ref_path_abs)
         study_selected_series_list = selector.filter('', study_list)
         self.study_selected_series = study_selected_series_list[0]  # select first Series in Study
 
     def test_create_dcm_input_dir(self):
-        Dcm2NiiOperator.create_dir(Path(self.monai_workdir / 'dcm_input'))
-        assert Path(self.monai_workdir / 'dcm_input').is_dir()
+        Dcm2NiiOperator.create_dir(Path(self.monai_workdir / 'dcm_input_dir'))
+        assert Path(self.monai_workdir / 'dcm_input_dir').is_dir()
 
     def test_create_nii_ct_dataset_dir(self):
         Dcm2NiiOperator.create_dir(Path(self.monai_workdir / 'nii_ct_dataset'))
         assert Path(self.monai_workdir / 'nii_ct_dataset').is_dir()
 
     def test_load_selected_series(self):
-        selected_series, num_instance_in_series = Dcm2NiiOperator.load_selected_series(self.study_selected_series)
+        selected_series, num_instances_in_series = Dcm2NiiOperator.load_selected_series(self.study_selected_series)
 
         # assert assuming number of DICOM instances loaded = number of files in test directory
-        num_files_in_dir = len([f for f in os.listdir(data_path.absolute()) if not f.startswith('.')])
-        assert num_instance_in_series == num_files_in_dir
+        num_files_in_dir = len([f for f in os.listdir(self.dcm_ref_path_abs) if not f.startswith('.')])
+        assert num_instances_in_series == num_files_in_dir
 
     def test_copy_dcm_to_workdir(self):
-        # TODO: need to importStudySelectedSeries from monai.deploy.core
-        pass
+        Dcm2NiiOperator.create_dir(Path(self.monai_workdir / 'dcm_input_dir'))
+        selected_series, num_instances_in_series = Dcm2NiiOperator.load_selected_series(self.study_selected_series)
+        Dcm2NiiOperator.copy_dcm_to_workdir(selected_series, num_instances_in_series,
+                                            Path(self.monai_workdir), 'dcm_input_dir')
+
+        # assert three DICOM files copied to monai_workdir
+        num_files_in_dir = len([f for f in os.listdir(Path(self.monai_workdir / 'dcm_input_dir'))
+                                if not f.startswith('.')])
+        assert num_instances_in_series == num_files_in_dir
 
     def test_load_nifti(self):
         nii_obj = nib.load(self.nii_ref_file)

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -27,6 +27,14 @@ class TestDcm2NiiConversion:
         Dcm2NiiOperator.create_dir(Path(self.monai_workdir / 'nii_ct_dataset'))
         assert Path(self.monai_workdir / 'nii_ct_dataset').is_dir()
 
+    def test_load_selected_series(self):
+        # TODO: need to import InputContext and StudySelectedSeries from monai.deploy.core
+        pass
+
+    def test_copy_dcm_to_workdir(self):
+        # TODO: need to importStudySelectedSeries from monai.deploy.core
+        pass
+
     def test_load_nifti(self):
         nii_obj = nib.load(self.nii_ref_file)
         assert issubclass(type(nii_obj), nib.nifti1.Nifti1Image)

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -11,12 +11,12 @@ from app.operators.dcm2nii_operator import Dcm2NiiOperator
 
 class TestDcm2NiiConversion:
     def setup_method(self):
-        self.dcm_ref_path = Path('data/dcm2nii/dcm/')
-        self.nii_ref_file = Path('data/dcm2nii/nii/ct-test-data.nii.gz')
-        self.nii_gen_path = Path('data/dcm2nii/nii_generated/')
+        self.dcm_ref_path = Path('tests/data/dcm2nii/dcm/')
+        self.nii_ref_file = Path('tests/data/dcm2nii/nii/ct-test-data.nii.gz')
+        self.nii_gen_path = Path('tests/data/dcm2nii/nii_generated/')
         self.nii_gen_filename = "generated-ct-test-data"
 
-        self.monai_workdir = Path('data/dcm2nii/monai_workdir')
+        self.monai_workdir = Path('tests/data/dcm2nii/monai_workdir')
         os.makedirs(self.monai_workdir, exist_ok=True)
 
     def test_create_dcm_input_dir(self):

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -55,10 +55,6 @@ class TestDcm2NiiConversion:
                                 if not f.startswith('.')])
         assert num_instances_in_series == num_files_in_dir
 
-    def test_load_nifti(self):
-        nii_obj = nib.load(self.nii_ref_file)
-        assert issubclass(type(nii_obj), nib.nifti1.Nifti1Image)
-
     def test_dcm2niix(self):
         os.makedirs(self.nii_gen_path, exist_ok=True)
         Dcm2NiiOperator.run_dcm2niix(

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -50,7 +50,7 @@ class TestDcm2NiiConversion:
         Dcm2NiiOperator.copy_dcm_to_workdir(selected_series, num_instances_in_series,
                                             Path(self.monai_workdir), 'dcm_input_dir')
 
-        # assert three DICOM files copied to monai_workdir
+        # assert number of DICOM files copied to monai_workdir = number in test dataset
         num_files_in_dir = len([f for f in os.listdir(Path(self.monai_workdir / 'dcm_input_dir'))
                                 if not f.startswith('.')])
         assert num_instances_in_series == num_files_in_dir

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from pathlib import Path
 
+from app.operators.dcm2nii_operator import Dcm2NiiOperator
+
 
 class TestDcm2NiiConversion:
     def setup_method(self):
@@ -13,13 +15,24 @@ class TestDcm2NiiConversion:
         self.nii_ref_file = Path('data/dcm2nii/nii/ct-test-data.nii.gz')
         self.nii_gen_path = Path('data/dcm2nii/nii_generated/')
 
+        self.monai_workdir = Path('data/dcm2nii/monai_workdir')
+        os.makedirs(self.monai_workdir, exist_ok=True)
+
+    def test_create_dcm_input_dir(self):
+        Dcm2NiiOperator.create_dir(Path(self.monai_workdir / 'dcm_input'))
+        assert Path(self.monai_workdir / 'dcm_input').is_dir()
+
+    def test_create_nii_ct_dataset_dir(self):
+        Dcm2NiiOperator.create_dir(Path(self.monai_workdir / 'nii_ct_dataset'))
+        assert Path(self.monai_workdir / 'nii_ct_dataset').is_dir()
+
     def test_load_nifti(self):
         nii_obj = nib.load(self.nii_ref_file)
         assert issubclass(type(nii_obj), nib.nifti1.Nifti1Image)
 
     def test_dcm2niix(self):
         os.makedirs(self.nii_gen_path, exist_ok=True)
-        subprocess.run(["dcm2niix", "-z", "y", "-o", self.nii_gen_path, "-f", "generated-ct-test-data",
+        subprocess.run(["dcm2niix", "-z", "y", "-b", "n", "-o", self.nii_gen_path, "-f", "generated-ct-test-data",
                         self.dcm_ref_path])
         img_ref = nib.load(self.nii_ref_file).get_fdata()
         img_gen = nib.load(self.nii_gen_path / 'generated-ct-test-data.nii.gz').get_fdata()
@@ -28,3 +41,7 @@ class TestDcm2NiiConversion:
 
         # remove test generated images
         shutil.rmtree(self.nii_gen_path)
+
+    def teardown_method(self):
+        # remove test monai_workdir structure
+        shutil.rmtree(self.monai_workdir)

--- a/tests/test_dcm2nii.py
+++ b/tests/test_dcm2nii.py
@@ -14,6 +14,7 @@ class TestDcm2NiiConversion:
         self.dcm_ref_path = Path('data/dcm2nii/dcm/')
         self.nii_ref_file = Path('data/dcm2nii/nii/ct-test-data.nii.gz')
         self.nii_gen_path = Path('data/dcm2nii/nii_generated/')
+        self.nii_gen_filename = "generated-ct-test-data"
 
         self.monai_workdir = Path('data/dcm2nii/monai_workdir')
         os.makedirs(self.monai_workdir, exist_ok=True)
@@ -32,10 +33,13 @@ class TestDcm2NiiConversion:
 
     def test_dcm2niix(self):
         os.makedirs(self.nii_gen_path, exist_ok=True)
-        subprocess.run(["dcm2niix", "-z", "y", "-b", "n", "-o", self.nii_gen_path, "-f", "generated-ct-test-data",
-                        self.dcm_ref_path])
+        Dcm2NiiOperator.run_dcm2niix(
+            self.dcm_ref_path,
+            self.nii_gen_path,
+            self.nii_gen_filename
+        )
         img_ref = nib.load(self.nii_ref_file).get_fdata()
-        img_gen = nib.load(self.nii_gen_path / 'generated-ct-test-data.nii.gz').get_fdata()
+        img_gen = nib.load((self.nii_gen_path / self.nii_gen_filename).with_suffix('.nii.gz')).get_fdata()
         images_equal = np.array_equal(img_ref, img_gen)
         assert images_equal, f"Generated image array not equal to reference image array"
 


### PR DESCRIPTION
- Restructures dcm2niix_operator to be more object-oriented, for better implementation with PyTest.
- Adds more unit tests to `test_dcm2nii.py`